### PR TITLE
Feature/bulkv2

### DIFF
--- a/communicator/redeem_token.go
+++ b/communicator/redeem_token.go
@@ -30,6 +30,7 @@ func asyncStreamingRetrieveContent(resp io.Reader) (chan *ArchiveEntryDownloadSy
 				if unmarshalErr != nil {
 					errCh <- unmarshalErr
 				} else {
+					log.Printf("DEBUG asyncStreamingRetrieveContent got %v", entry)
 					outputCh <- &entry
 				}
 			} else {
@@ -94,6 +95,7 @@ func (comm *Communicator) FetchDownloadSynopsisStreaming(partialResponse *BulkDo
 	} else {
 		copiedResponse := *partialResponse
 		copiedResponse.Entries = *entriesPtr
+		log.Printf("DEBUG FetchDownloadSynopsisStreaming got final result %v", copiedResponse)
 		return &copiedResponse, nil
 	}
 }

--- a/communicator/redeem_token.go
+++ b/communicator/redeem_token.go
@@ -1,15 +1,102 @@
 package communicator
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/guardian/autopull/config"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
 )
+
+/**
+consumes an NDJSON stream of ArchiveEntryDownloadSynopsis and yields them to the returned channels
+*/
+func asyncStreamingRetrieveContent(resp io.Reader) (chan *ArchiveEntryDownloadSynopsis, chan error) {
+	outputCh := make(chan *ArchiveEntryDownloadSynopsis, 100)
+	errCh := make(chan error, 100)
+
+	go func() {
+		scanner := bufio.NewScanner(resp)
+		for scanner.Scan() {
+			rawContent := scanner.Bytes()
+			if len(rawContent) > 0 {
+				var entry ArchiveEntryDownloadSynopsis
+				unmarshalErr := json.Unmarshal(rawContent, &entry)
+				if unmarshalErr != nil {
+					errCh <- unmarshalErr
+				} else {
+					outputCh <- &entry
+				}
+			} else {
+				log.Printf("INFO asyncStreamingRetrieveContent got zero-length record")
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			errCh <- err
+		}
+		outputCh <- nil
+		return
+	}()
+
+	return outputCh, errCh
+}
+
+func consumeDownloadStream(resp io.Reader) (*[]ArchiveEntryDownloadSynopsis, error) {
+	output := make([]ArchiveEntryDownloadSynopsis, 0)
+
+	contentCh, errCh := asyncStreamingRetrieveContent(resp)
+	var lastError error
+
+	for {
+		select {
+		case rec := <-contentCh:
+			if rec == nil {
+				log.Print("INFO consumeDownloadStream reached end of stream")
+				if lastError != nil {
+					return nil, lastError
+				} else {
+					return &output, nil
+				}
+			}
+			output = append(output, *rec)
+		case err := <-errCh:
+			log.Print("WARNING consumeDownloadStream got an error: ", err)
+			lastError = err
+		}
+	}
+}
+
+/**
+the V2 api separates the token get and retrieval stages.  The BulkDownloadInitiate response has a nil entries list, which
+we must populate with a subsequent call to summaryStream.
+This function consumes the result of summaryStream and fills the 'entries' field for us.
+*/
+func (comm *Communicator) FetchDownloadSynopsisStreaming(partialResponse *BulkDownloadInitiateResponse, httpClient *http.Client, attempt int) (*BulkDownloadInitiateResponse, error) {
+	log.Printf("DEBUG communicator.RedeemToken no download synopsis data, retrieving from stream...")
+
+	url := fmt.Sprintf("%s/api/bulkv2/%s/summarystream", comm.ArchiveHunterUri.String(), partialResponse.RetrievalToken)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		log.Printf("ERROR communicator.FetchDownloadSynopsisStreaming could not make connection to server: %s", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	entriesPtr, retrieveErr := consumeDownloadStream(resp.Body)
+	if retrieveErr != nil {
+		return nil, retrieveErr
+	} else {
+		copiedResponse := *partialResponse
+		copiedResponse.Entries = *entriesPtr
+		return &copiedResponse, nil
+	}
+}
 
 /**
 redeems the short-lived token and returns a pointer to the decoded response, or returns an error
@@ -20,7 +107,7 @@ func (comm *Communicator) RedeemToken(token config.DownloadTokenUri, attempt int
 	if token.ValidateVaultDoor() {
 		url = fmt.Sprintf("%s/api/bulk/%s", comm.VaultDoorUri.String(), token.Token)
 	} else {
-		url = fmt.Sprintf("%s/api/bulk/%s", comm.ArchiveHunterUri.String(), token.Token)
+		url = fmt.Sprintf("%s/api/bulkv2/%s", comm.ArchiveHunterUri.String(), token.Token)
 	}
 
 	resp, err := client.Get(url)
@@ -45,7 +132,11 @@ func (comm *Communicator) RedeemToken(token config.DownloadTokenUri, attempt int
 			log.Printf("ERROR communicator.RedeemToken could not understand server response: %s", unmarshalErr)
 			return nil, unmarshalErr
 		}
-		return &info, nil
+		if info.Entries == nil {
+			return comm.FetchDownloadSynopsisStreaming(&info, &client, 0)
+		} else {
+			return &info, nil
+		}
 	case 502:
 		fallthrough
 	case 503:

--- a/downloadmanager/downloadmanager.go
+++ b/downloadmanager/downloadmanager.go
@@ -172,7 +172,7 @@ func doDownload(pathTarget string, downloadUrl string, expectedSize int64) (bool
 
 	switch dlResponse.StatusCode {
 	case 200:
-		log.Printf("INFO DownloadManager.PerformDownload downloading %s to %s", downloadUrl, pathTarget)
+		//log.Printf("INFO DownloadManager.PerformDownload downloading %s to %s", downloadUrl, pathTarget)
 		bytesCopied, copyErr := io.Copy(file, dlResponse.Body)
 		if copyErr != nil {
 			log.Printf("ERROR DownloadManager.PerformDownload download of %s failed: %s", pathTarget, copyErr)


### PR DESCRIPTION
## What does this change?
Implements the "bulk v2" protocol from https://github.com/guardian/archivehunter/pull/89 in order to improve overall speed and prevent timeout errors on large bulk downloads

## How to test
Ensure that  https://github.com/guardian/archivehunter/pull/89 is in place on the server you're targetting; edit autopull.yaml if necessary.
Then attempt to download a large (>1500 item) bulk.  You should see it quickly obtain the long-token then spool out a list of the files as it streams them in before doing the download as normal

## How can we measure success?
Large bulk downloads don't error out

## Have we considered potential risks?
No risks because this mode does not replace existing functionality and because it's only enabled if the returned entries list does not exist
